### PR TITLE
rpm spec file for Fedora Atomic desktop users

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ Tracking in https://github.com/thesofproject/sof/issues/9759
   options snd_sof_pci tplg_filename=sof-lnl-cs42l43-l0-cs35l56-l23-2ch.tplg
   ```
 * Kernel-side change (seems) targeted 6.15
+* An [rpm .spec file](zenbook-s14-dmic.spec) is provided for Fedora Atomic desktop users.  
+  Build with:
+  ```
+  rpmbuild -bb zenbook-s14-dmic.spec
+  ```
+  and install the resulting rpm with:
+  ```
+  sudo rpm-ostree install --force-replacefiles $HOME/rpmbuild/RPMS/$(uname -m)/zenbook-s14-dmic-*.rpm
+  ```
 
 ### USB
 

--- a/zenbook-s14-dmic.spec
+++ b/zenbook-s14-dmic.spec
@@ -1,0 +1,50 @@
+%define        __spec_install_post %{nil}
+%define          debug_package %{nil}
+%define        __os_install_post %{_dbpath}/brp-compress
+
+Name: zenbook-s14-dmic
+Version: 0.1
+Release: %autorelease
+Summary: Patch to enable microphone in ASUS Zenbook S14
+
+License: GPL+
+URL: https://github.com/dantmnf/zenbook-s14-linux
+
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-BuildRoot
+
+%description
+%{summary}
+
+%prep
+
+
+%build
+wget "https://raw.githubusercontent.com/alsa-project/alsa-ucm-conf/refs/heads/master/ucm2/sof-soundwire/cs42l43.conf"
+wget "https://github.com/dantmnf/zenbook-s14-linux/raw/refs/heads/master/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0-cs35l56-l23-2ch.tplg"
+echo "\
+# quirk=RT711_JD1|SOC_SDW_PCH_DMIC|SOC_SDW_CODEC_MIC
+# RT711_JD1: default quirk value
+# SOC_SDW_PCH_DMIC: force enumerate DMIC connected to PCH
+# SOC_SDW_CODEC_MIC: don't enumerate DMIC connected to SoundWire CODEC
+options snd_soc_sof_sdw quirk=0x20041
+options snd_sof_pci tplg_filename=sof-lnl-cs42l43-l0-cs35l56-l23-2ch.tplg\
+" > ./ux5406-dmic.conf
+
+
+%install
+mkdir -p %{buildroot}/usr/share/alsa/ucm2/sof-soundwire
+cp ./cs42l43.conf %{buildroot}/usr/share/alsa/ucm2/sof-soundwire/
+mkdir -p %{buildroot}/lib/firmware/intel/sof-ipc4-tplg
+cp ./sof-lnl-cs42l43-l0-cs35l56-l23-2ch.tplg %{buildroot}/lib/firmware/intel/sof-ipc4-tplg/
+mkdir -p %{buildroot}/etc/modprobe.d
+cp ./ux5406-dmic.conf %{buildroot}/etc/modprobe.d/
+
+
+%files
+/usr/share/alsa/ucm2/sof-soundwire/cs42l43.conf
+/lib/firmware/intel/sof-ipc4-tplg/sof-lnl-cs42l43-l0-cs35l56-l23-2ch.tplg
+/etc/modprobe.d/ux5406-dmic.conf
+
+
+%changelog
+%autochangelog


### PR DESCRIPTION
I put some effort into turning the DMIC instructions into an rpm spec to be used with rpm-ostree on Fedora Atomic Desktops. This is necessary to make these changes to the otherwise immutable OS.

I figured I'd share the effort in case anyone else needs it.