### PR TITLE
Added README chapter showing how to fix sound issues after kernel upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,21 @@ Tracking in https://github.com/thesofproject/sof/issues/9759
   sudo rpm-ostree install --force-replacefiles $HOME/rpmbuild/RPMS/$(uname -m)/zenbook-s14-dmic-*.rpm
   ```
 
+#### Updating from kernels without upstream patches to newer ones with patches
+
+In case you have followed all the steps above, but now you are upgrading to a newer kernel version (see Audio component [in this table](#linux-enablement-overview)), you will most probably encounter an issue where audio stops working entirely - both speakers and microphones.
+
+To resolve this without full system reinstall, you simply need to undo steps [above](#before-necessary-patches-merged-in-upstream), specifically:
+
+* Reinstall `alsa-ucm` (or `alsa-lib` completely if you want), `sof-firmware`, `linux-firmware` to their latest versions. 
+  - Example for Fedora: `sudo dnf reinstall alsa-ucm alsa-sof-firmware linux-firmware`.
+
+* Remove the `sof-lnl-cs42l43-l0-cs35l56-l23-2ch.tplg` from `/lib/firmware/intel/sof-ipc4-tplg/`. Make sure that file with the same name but a `.tplg.xz` extension exists.
+
+* Completely remove the `/etc/modprobe.d/ux5406-dmic.conf` file.
+
+* Custom `cs42l43.conf` should be replaced automatically on packages reinstall.
+
 ### Dual-boot issues
 
 > [!NOTE]


### PR DESCRIPTION
If a user has applied all the patches described in this repo on an older kernel and is now upgrading to a newer one, they may encounter a problem where all sound devices stop functioning (with several errors appearing in `dmesg`).

In order to fix this without full reinstall, just undoing all the steps described in this repo is sufficient.

I have checked [this discussion](https://github.com/thesofproject/sof/issues/9759) and it seems that some people are having trouble with their system, even performing a fresh OS reinstall unnecessarily. I would like to add this small chapter so users will know how to seamlessly upgrade to the newest kernel while keeping sound working on this laptop.

Tested on Fedora 41 16.4.5 kernel and when transitioning Fedora 41 -> 42.